### PR TITLE
Add separate issue template for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
 // REMOVE LINES WITH SLASHES, LIKE THIS
 
 **Steps to reproduce**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea NethServer project
+about: We encourage the discussion of new features on community.nethserver.org. After coming to a consensus, please fill in this form
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest an idea NethServer project
+
+---
+
+// REMOVE LINES WITH SLASHES, LIKE THIS
+
+// Is your feature request related to a problem? Please describe.
+// A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Proposed solution**
+
+// Describe the solution you'd like
+// A clear and concise description of what you want to happen.
+
+**Alternative solutions**
+
+// Describe alternatives you've considered
+// A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+// Add any other context or screenshots about the feature request here.
+
+**See also**
+
+// Links to discussion on community.nethserver.org and other web sites
+
+----
+
+// Acknowledgements


### PR DESCRIPTION
Github has support for create multiple templates in a single repository, in this way one can for example propose a different template in case of bug report or a feature request, see:
- https://blog.github.com/2018-05-02-issue-template-improvements/
- https://blog.github.com/2018-01-25-multiple-issue-and-pull-request-templates/

This pull request add a new template for feature request issues as wrote in the NethServer's Developer Manual: http://docs.nethserver.org/projects/nethserver-devel/en/latest/development_process.html#issues