### PR TITLE
Dev manual improvements

### DIFF
--- a/developer-manual/building_iso.rst
+++ b/developer-manual/building_iso.rst
@@ -11,13 +11,14 @@ To create a NethServer ISO on a NethServer system, follow these steps:
 
 1) Install ``nethserver-createiso`` package
 
-2) Log in as a non-privileged user, member of the ``mock`` group
-   
-3) Download CentOS minimal ISO
-   
-4) Run ``createiso`` command ::
+2) Make sure mock cache is clean, execute as ``root`` user: ::
 
-     createiso  -i CentOS-7.2.1511-x86_64-minimal.iso -n nethserver -v 7.2.1511-beta1
+     rm -rf /var/cache/mock/nethserver-iso*
 
+3) Log in as a non-privileged user, member of the ``mock`` group
 
+4) Download CentOS minimal ISO
 
+5) Run ``createiso`` command ::
+
+     createiso -n nethserver -v 7.9.2009 -i CentOS-7-x86_64-Minimal-2009.iso

--- a/developer-manual/conf.py
+++ b/developer-manual/conf.py
@@ -12,7 +12,7 @@
 # serve to show the default.
 
 import sys, os
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -41,8 +41,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'NethServer'
-copyright = u'2017, Nethesis Srl'
+project = 'NethServer'
+copyright = '2017, Nethesis Srl'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -185,8 +185,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'NethServer.tex', u'NethServer Documentation',
-   u'Nethesis', 'manual'),
+  ('index', 'NethServer.tex', 'NethServer Documentation',
+   'Nethesis', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -215,8 +215,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'nethserver', u'NethServer Documentation',
-     [u'Nethesis'], 1)
+    ('index', 'nethserver', 'NethServer Documentation',
+     ['Nethesis'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -229,8 +229,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'NethServer', u'NethServer Documentation',
-   u'Nethesis', 'NethServer', 'One line description of project.',
+  ('index', 'NethServer', 'NethServer Documentation',
+   'Nethesis', 'NethServer', 'One line description of project.',
    'Miscellaneous'),
 ]
 
@@ -244,7 +244,7 @@ def setup(app):
         line = fp.readline().strip()
         while line:
             url = "https://raw.githubusercontent.com/NethServer/%s/master/README.rst" % line
-            urllib.urlretrieve(url, line+".rst")
-            print "Downloading %s: %s" % (line, url)
+            urllib.request.urlretrieve(url, line+".rst")
+            print("Downloading %s: %s" % (line, url))
             line = fp.readline().strip()
     fp.close()

--- a/developer-manual/development_process.rst
+++ b/developer-manual/development_process.rst
@@ -145,7 +145,7 @@ The *Developer*.
 * Finally, clears the *Assignee*.
 
 If the issue is not valid, it must be closed using the **invalid** label.
-A comment must convey the reason why it is invalid, like *duplicate of (URL of issue)*, *wontfix because ...".
+A comment must convey the reason why it is invalid, like *"duplicate of (URL of issue), wontfix because ..."*.
 
 
 .. _qa-section:
@@ -184,7 +184,7 @@ After the *QA member* has completed the testing phase:
 
 * Takes an unassigned issue with label **verified**
 
-* Commits a *release tag* (see `Building RPMs`_).
+* Commits a *release tag* (see :ref:`buildrpm-section`).
 
 * Re-builds the tagged RPM.
 


### PR DESCRIPTION
- Better describe ISO process
- Minor syntax fixes
- Use Python 3 for `conf.py`: python version switched inside ReadTheDocs config: https://readthedocs.org/projects/nethserver-devel/